### PR TITLE
Slight change to deployment steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ Make sure all your changes are committed.
 Then run:
 
 ```bash
-make prepare-release
+git checkout master
+git pull
+bumpversion [part]
 git push
 git push --tags
 git branch -D stable
@@ -62,4 +64,5 @@ git checkout -b stable
 git push --set-upstream origin stable -f
 ```
 
+Where `[part]` is `major`, `minor`, or `patch`.
 This will release a new package version on Git + GitHub and publish to PyPI.


### PR DESCRIPTION
Since there's no `Makefile` changed from `make prepare-release` to `bumpversion [part]`.